### PR TITLE
Minor fixes

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="EntryPointsManager">
-    <entry_points version="2.0" />
+  <component name="ASMPluginConfiguration">
+    <asm skipDebug="false" skipFrames="false" skipCode="false" expandFrames="false" />
+    <groovy codeStyle="LEGACY" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>
-

--- a/ant.xml
+++ b/ant.xml
@@ -25,7 +25,7 @@
     <target name="compile" depends="clean">
         <buildnumber/>
         <mkdir dir="${classes.dir}"/>
-        <javac srcdir="${src.dir}" destdir="${classes.dir}" classpathref="classpath" debug="true" debuglevel="lines,vars,source" deprecation="true"/>
+        <javac includeantruntime="false" srcdir="${src.dir}" destdir="${classes.dir}" classpathref="classpath" debug="true" debuglevel="lines,vars,source" deprecation="true"/>
     </target>
 
     <target name="jar" depends="compile,injectVersion">

--- a/src/no/runsafe/moosic/commands/MakeRecord.java
+++ b/src/no/runsafe/moosic/commands/MakeRecord.java
@@ -24,7 +24,7 @@ public class MakeRecord extends PlayerCommand implements IConfigurationChanged
 	{
 		RunsafeMeta item = Item.Special.Crafted.EnchantedBook.getItem();
 		item.setAmount(1);
-		item.addLore(parameters.get("song")).setDisplayName(customRecordName);
+		item.addLore((String) parameters.getValue("song")).setDisplayName(customRecordName);
 		executor.getInventory().addItems(item);
 		return "&2Success!";
 	}

--- a/src/no/runsafe/moosic/commands/PlaySong.java
+++ b/src/no/runsafe/moosic/commands/PlaySong.java
@@ -26,7 +26,7 @@ public class PlaySong extends PlayerCommand
 	@Override
 	public String OnExecute(IPlayer executor, IArgumentList parameters)
 	{
-		File song = this.musicHandler.loadSongFile(parameters.get("song"));
+		File song = this.musicHandler.loadSongFile((String) parameters.getValue("song"));
 
 		if (!song.exists())
 			return "&cThat song does not exist.";

--- a/src/no/runsafe/moosic/commands/PlaySong.java
+++ b/src/no/runsafe/moosic/commands/PlaySong.java
@@ -16,8 +16,8 @@ public class PlaySong extends PlayerCommand
 	{
 		super(
 			"playsong", "Plays a song at your location.", "runsafe.moosic.play",
-				new DecimalNumber("volume").withDefault(1.0F).require(),
-				new TrailingArgument("song").require()
+			new DecimalNumber("volume").withDefault(1.0F).require(),
+			new TrailingArgument("song").require()
 		);
 		this.musicHandler = musicHandler;
 

--- a/src/no/runsafe/moosic/commands/PlaySong.java
+++ b/src/no/runsafe/moosic/commands/PlaySong.java
@@ -1,7 +1,7 @@
 package no.runsafe.moosic.commands;
 
+import no.runsafe.framework.api.command.argument.DecimalNumber;
 import no.runsafe.framework.api.command.argument.IArgumentList;
-import no.runsafe.framework.api.command.argument.RequiredArgument;
 import no.runsafe.framework.api.command.argument.TrailingArgument;
 import no.runsafe.framework.api.command.player.PlayerCommand;
 import no.runsafe.framework.api.player.IPlayer;
@@ -16,7 +16,7 @@ public class PlaySong extends PlayerCommand
 	{
 		super(
 			"playsong", "Plays a song at your location.", "runsafe.moosic.play",
-				new RequiredArgument("volume"),
+				new DecimalNumber("volume").withDefault(1.0F).require(),
 				new TrailingArgument("song").require()
 		);
 		this.musicHandler = musicHandler;
@@ -36,7 +36,7 @@ public class PlaySong extends PlayerCommand
 			int id = this.musicHandler.startSong(
 				new MusicTrack(song),
 				executor.getLocation(),
-				Float.valueOf(parameters.get("volume"))
+				(Float) parameters.getValue("volume")
 			);
 			return "&2Playing song with player ID: " + id;
 		}

--- a/src/no/runsafe/moosic/commands/PlaySong.java
+++ b/src/no/runsafe/moosic/commands/PlaySong.java
@@ -2,6 +2,7 @@ package no.runsafe.moosic.commands;
 
 import no.runsafe.framework.api.command.argument.IArgumentList;
 import no.runsafe.framework.api.command.argument.RequiredArgument;
+import no.runsafe.framework.api.command.argument.TrailingArgument;
 import no.runsafe.framework.api.command.player.PlayerCommand;
 import no.runsafe.framework.api.player.IPlayer;
 import no.runsafe.moosic.MusicHandler;
@@ -15,7 +16,8 @@ public class PlaySong extends PlayerCommand
 	{
 		super(
 			"playsong", "Plays a song at your location.", "runsafe.moosic.play",
-			new RequiredArgument("song"), new RequiredArgument("volume")
+				new RequiredArgument("volume"),
+				new TrailingArgument("song").require()
 		);
 		this.musicHandler = musicHandler;
 

--- a/src/no/runsafe/moosic/commands/StopSong.java
+++ b/src/no/runsafe/moosic/commands/StopSong.java
@@ -3,7 +3,7 @@ package no.runsafe.moosic.commands;
 import no.runsafe.framework.api.command.ExecutableCommand;
 import no.runsafe.framework.api.command.ICommandExecutor;
 import no.runsafe.framework.api.command.argument.IArgumentList;
-import no.runsafe.framework.api.command.argument.RequiredArgument;
+import no.runsafe.framework.api.command.argument.WholeNumber;
 import no.runsafe.moosic.MusicHandler;
 
 public class StopSong extends ExecutableCommand
@@ -12,7 +12,7 @@ public class StopSong extends ExecutableCommand
 	{
 		super(
 			"stopsong", "Stops a song using its player ID", "runsafe.moosic.stop",
-			new RequiredArgument("playerID")
+			new WholeNumber("playerID").require()
 		);
 		this.musicHandler = musicHandler;
 	}
@@ -20,7 +20,9 @@ public class StopSong extends ExecutableCommand
 	@Override
 	public String OnExecute(ICommandExecutor executor, IArgumentList parameters)
 	{
-		int playerID = Integer.valueOf(parameters.get("playerID"));
+		Integer playerID = parameters.getValue("playerID");
+		if (playerID == null)
+			return "&cInvalid playerID.";
 		if (this.musicHandler.forceStop(playerID))
 			return "&2Stopping song with player ID " + playerID;
 

--- a/src/no/runsafe/moosic/customjukebox/CustomRecordHandler.java
+++ b/src/no/runsafe/moosic/customjukebox/CustomRecordHandler.java
@@ -92,7 +92,9 @@ public class CustomRecordHandler implements IConfigurationChanged, IPlayerRightC
 
 	private boolean isCustomRecord(RunsafeItemStack item)
 	{
-		return item instanceof RunsafeMeta && ((RunsafeMeta) item).getDisplayName().equalsIgnoreCase(customRecordName);
+		return item instanceof RunsafeMeta
+			&& customRecordName.equalsIgnoreCase(((RunsafeMeta) item).getDisplayName())
+			&& ((RunsafeMeta) item).hasLore();
 	}
 
 	public CustomJukebox getJukeboxAtLocation(ILocation location)


### PR DESCRIPTION
- Reduces deprecation
- Stops jukeboxes from eating music books and throwing a null pointer exception when a record book doesn't have any lore
- Fixes an issue with not being able to play songs using the /playsong command that had spaces in them.