### PR TITLE
fix issue with playing books 

### DIFF
--- a/src/no/runsafe/moosic/customjukebox/CustomRecordHandler.java
+++ b/src/no/runsafe/moosic/customjukebox/CustomRecordHandler.java
@@ -42,34 +42,25 @@ public class CustomRecordHandler implements IConfigurationChanged, IPlayerRightC
 	public boolean OnPlayerRightClick(IPlayer player, RunsafeMeta usingItem, IBlock targetBlock)
 	{
 		ILocation blockLocation = targetBlock.getLocation();
-		if (targetBlock instanceof IJukebox)
+		if (!(targetBlock instanceof IJukebox))
+			return true;
+
+		CustomJukebox jukebox = getJukeboxAtLocation(blockLocation);
+		if (jukebox != null)
 		{
-			CustomJukebox jukebox = getJukeboxAtLocation(blockLocation);
-			if (jukebox != null)
-			{
-				stopJukebox(jukebox);
-				return false;
-			}
-			else
-			{
-				if (usingItem != null)
-				{
-					if (usingItem.is(Item.Special.Crafted.EnchantedBook))
-					{
-						if (this.isCustomRecord(usingItem))
-						{
-							((IJukebox) targetBlock).eject();
-							player.removeExactItem(usingItem, 1);
-							jukebox = playJukebox(player, new CustomJukebox(blockLocation, usingItem));
-							repository.storeJukebox(blockLocation, usingItem);
-							jukeboxes.add(jukebox);
-							return false;
-						}
-					}
-				}
-			}
+			stopJukebox(jukebox);
+			return false;
 		}
-		return true;
+
+		if (usingItem == null || !usingItem.is(Item.Special.Crafted.EnchantedBook) || !isCustomRecord(usingItem))
+			return true;
+
+		((IJukebox) targetBlock).eject();
+		player.removeExactItem(usingItem, 1);
+		jukebox = playJukebox(player, new CustomJukebox(blockLocation, usingItem));
+		repository.storeJukebox(blockLocation, usingItem);
+		jukeboxes.add(jukebox);
+		return false;
 	}
 
 	@Override

--- a/src/no/runsafe/moosic/customjukebox/CustomRecordHandler.java
+++ b/src/no/runsafe/moosic/customjukebox/CustomRecordHandler.java
@@ -55,7 +55,9 @@ public class CustomRecordHandler implements IConfigurationChanged, IPlayerRightC
 		if (usingItem == null || !usingItem.is(Item.Special.Crafted.EnchantedBook) || !isCustomRecord(usingItem))
 			return true;
 
-		((IJukebox) targetBlock).eject();
+		if (((IJukebox) targetBlock).isPlaying())
+			((IJukebox) targetBlock).eject();
+
 		player.removeExactItem(usingItem, 1);
 		jukebox = playJukebox(player, new CustomJukebox(blockLocation, usingItem));
 		repository.storeJukebox(blockLocation, usingItem);


### PR DESCRIPTION
attempt to fix issue with playing a record book when nothing is already in the jukebox. I suspect that the .eject() method runs at the end of the OnPlayerRightClick() method instead of where it is due to weird quirks I've spotted elsewhere, only ejecting when there's already something in the jukebox playing should fix this